### PR TITLE
Fix double 'url()' for sprites due to Rails asset-url

### DIFF
--- a/lib/bootstrap-chosen-rails/version.rb
+++ b/lib/bootstrap-chosen-rails/version.rb
@@ -1,5 +1,5 @@
 module BootstrapChosenRails
   module Rails
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end

--- a/vendor/assets/stylesheets/bootstrap-chosen.scss
+++ b/vendor/assets/stylesheets/bootstrap-chosen.scss
@@ -115,13 +115,13 @@
     bottom: 0;
 
     span {
-      background: url($chosen-sprite-path) no-repeat -4px -3px;
+      background: $chosen-sprite-path no-repeat -4px -3px;
     }
   }
 
   .chosen-results-scroll-up {
     span {
-      background: url($chosen-sprite-path) no-repeat -22px -3px;
+      background: $chosen-sprite-path no-repeat -22px -3px;
     }
   }
 }
@@ -153,7 +153,7 @@
     }
 
     abbr {
-      background: url($chosen-sprite-path) right top no-repeat;
+      background: $chosen-sprite-path right top no-repeat;
       display: block;
       font-size: 1px;
       height: 10px;
@@ -180,7 +180,7 @@
       width: 18px;
 
       b {
-        background: url($chosen-sprite-path) no-repeat 0 7px;
+        background: $chosen-sprite-path no-repeat 0 7px;
         display: block;
         height: 100%;
         width: 100%;
@@ -200,7 +200,7 @@
     z-index: $zindex-dropdown;
 
     input[type="text"] {
-      background: url($chosen-sprite-path) no-repeat 100% -20px, $chosen-background;
+      background: $chosen-sprite-path no-repeat 100% -20px, $chosen-background;
       border: $chosen-border;
       @include border-top-radius($chosen-border-radius);
       @include border-bottom-radius($chosen-border-radius);
@@ -288,7 +288,7 @@
       position: relative;
 
       .search-choice-close {
-        background: url($chosen-sprite-path) right top no-repeat;
+        background: $chosen-sprite-path right top no-repeat;
         display: block;
         font-size: 1px;
         height: 10px;
@@ -438,7 +438,7 @@
   }
 
   .chosen-search input[type="text"] {
-    background: url($chosen-sprite-path) no-repeat -28px -20px, $chosen-background;
+    background: $chosen-sprite-path no-repeat -28px -20px, $chosen-background;
     direction: rtl;
     padding: 4px 5px 4px 20px;
   }
@@ -452,7 +452,7 @@
   .chosen-container-multi .chosen-choices .search-choice .search-choice-close,
   .chosen-container .chosen-results-scroll-down span,
   .chosen-container .chosen-results-scroll-up span {
-    background-image: url($chosen-sprite-retina-path) !important;
+    background-image: $chosen-sprite-retina-path !important;
     background-size: 52px 37px !important;
     background-repeat: no-repeat !important;
   }


### PR DESCRIPTION
Currently, the compiled css ends up with sprite URLs wrapped _twice_ with url(), like so:

```
    background: url(url(/assets/chosen-sprite.png)) no-repeat 0 7px;
```

This caused [minor alignment issues](http://imgur.com/C6VCnPk).

Pull request fixes the issue by removing the url() in 8 places in bootstrap-chosen.scss. Alternatively, we could replace asset-url with asset-path in 2 places in bootstrap-chosen-variables.scss. Let me know if you'd prefer that.

Signed-off-by: Rory Stolzenberg rory@getfoodio.com
